### PR TITLE
Cope with broken vendors, plus tests

### DIFF
--- a/lib/analytics_x.dart
+++ b/lib/analytics_x.dart
@@ -22,9 +22,8 @@ class AnalyticsX {
       return;
     }
 
-    await Future.wait(newVendors.map((vendor) => vendor.init())); //Do all the inits in parallel
-
-    _vendors.addAll(List.from(newVendors));
+    //Do all the inits in parallel, and add them to the list on successful completion
+    await Future.wait(newVendors.map((vendor) => vendor.init().then((_) => _vendors.add(vendor))));
   }
 
   Future<void> invokeAction(AnalyticsAction action, [List<String> vendorIds = ALL]) async {

--- a/lib/analytics_x.dart
+++ b/lib/analytics_x.dart
@@ -5,9 +5,12 @@ import 'package:analyticsx/analytics_vendor.dart';
 
 const ALL = ['all'];
 
+typedef AnalyticsError = Function(Object error, StackTrace stack);
+
 class AnalyticsX {
   static final AnalyticsX _instance = AnalyticsX._internal();
   final List<AnalyticsVendor> _vendors = [];
+  late AnalyticsError? onError;
 
   factory AnalyticsX() {
     return _instance;
@@ -15,7 +18,9 @@ class AnalyticsX {
 
   AnalyticsX._internal();
 
-  Future<void> init(List<AnalyticsVendor> vendors) async {
+  Future<void> init(List<AnalyticsVendor> vendors, [AnalyticsError? onError]) async {
+    this.onError = onError;
+
     final newVendors = List<AnalyticsVendor>.from(vendors)..removeWhere((v) => _vendors.contains(v));
 
     if (newVendors.isEmpty) {
@@ -23,13 +28,31 @@ class AnalyticsX {
     }
 
     //Do all the inits in parallel, and add them to the list on successful completion
-    await Future.wait(newVendors.map((vendor) => vendor.init().then((_) => _vendors.add(vendor))));
+    await Future.wait(newVendors.map((vendor) => _initAndAddVendor(vendor)));
   }
 
   Future<void> invokeAction(AnalyticsAction action, [List<String> vendorIds = ALL]) async {
     final List<AnalyticsVendor> vendorsToUse = _filterVendors(vendorIds);
 
-    await Future.wait(vendorsToUse.map((vendor) => vendor.handleAction(action))); //Do all the actions in parallel
+    await Future.wait(
+        vendorsToUse.map((vendor) => _handleActionSafely(vendor, action))); //Do all the actions in parallel
+  }
+
+  Future<void> _initAndAddVendor(AnalyticsVendor vendor) async {
+    try {
+      await vendor.init();
+      _vendors.add(vendor);
+    } catch (error, stack) {
+      onError?.call(error, stack);
+    }
+  }
+
+  Future<void> _handleActionSafely(AnalyticsVendor vendor, AnalyticsAction action) async {
+    try {
+      await vendor.handleAction(action);
+    } catch (error, stack) {
+      onError?.call(error, stack);
+    }
   }
 
   List<AnalyticsVendor> _filterVendors(List<String> vendorIds) {
@@ -40,7 +63,5 @@ class AnalyticsX {
     return _vendors.where((element) => ids.contains(element.id)).toList();
   }
 
-  void uninit() {
-    _vendors.clear();
-  }
+  void reset() => _vendors.clear();
 }

--- a/test/analytics_x_test.dart
+++ b/test/analytics_x_test.dart
@@ -13,7 +13,7 @@ void main() {
   });
 
   tearDown(() {
-    ax.uninit();
+    ax.reset();
   });
 
   test('AnalyticsX is (probably) a singleton', () async {

--- a/test/analytics_x_test.dart
+++ b/test/analytics_x_test.dart
@@ -1,38 +1,7 @@
-import 'package:analyticsx/analytics_action.dart';
-import 'package:analyticsx/analytics_vendor.dart';
 import 'package:analyticsx/analytics_x.dart';
 import 'package:test/test.dart';
 
-class FakeAction extends AnalyticsAction {
-  final String fakeProperty;
-  FakeAction(this.fakeProperty);
-}
-
-class FakeVendor extends AnalyticsVendor {
-  FakeVendor() : super('Dummy');
-  FakeVendor.withVendorId(String vendorId) : super(vendorId);
-
-  int initWasCalledXTimes = 0;
-  int handleActionWasCalledXTimes = 0;
-  List<String> handleActionWasCalledWith = [];
-
-  @override
-  Future<void> handleAction(AnalyticsAction action) async {
-    handleActionWasCalledXTimes++;
-    if (action is FakeAction) {
-      handleActionWasCalledWith.add(action.fakeProperty);
-    }
-  }
-
-  @override
-  Future<void> init() async {
-    initWasCalledXTimes++;
-  }
-}
-
-class FakeVendor2 extends FakeVendor {
-  FakeVendor2() : super.withVendorId('Dummy2');
-}
+import 'util/vendors_and_actions.dart';
 
 void main() {
   late FakeVendor fakeVendor;

--- a/test/broken_vendor_test.dart
+++ b/test/broken_vendor_test.dart
@@ -13,19 +13,19 @@ void main() {
   });
 
   tearDown(() {
-    ax.uninit();
+    ax.reset();
   });
 
   test('Broken vendor does not stop other vendors from initing', () async {
     final brokenVendor = BrokenFakeVendor(initWillThrow: true);
-    await ax.init([brokenVendor, fakeVendor]).catchError((_) => {/*nothing*/});
+    await ax.init([brokenVendor, fakeVendor]);
 
     expect(fakeVendor.initWasCalledXTimes, 1);
   });
 
   test('Broken vendor that fails to init never runs actions', () async {
     final brokenVendor = BrokenFakeVendor(initWillThrow: true);
-    await ax.init([brokenVendor, fakeVendor]).catchError((_) => {/*nothing*/});
+    await ax.init([brokenVendor, fakeVendor]);
     await ax.invokeAction(FakeAction("potato"));
     await ax.invokeAction(FakeAction("potato"), [brokenVendor.id]);
     expect(brokenVendor.handleActionWasCalledXTimes, 0);
@@ -34,7 +34,7 @@ void main() {
   test('Broken vendor does not stop other vendors from performing actions', () async {
     final brokenVendor = BrokenFakeVendor(handleActionWillThrow: true);
     await ax.init([brokenVendor, fakeVendor]);
-    await ax.invokeAction(FakeAction("potato")).catchError((_) => {/*nothing*/});
+    await ax.invokeAction(FakeAction("potato"));
     expect(fakeVendor.handleActionWasCalledXTimes, 1);
   });
 }

--- a/test/broken_vendor_test.dart
+++ b/test/broken_vendor_test.dart
@@ -1,0 +1,40 @@
+import 'package:analyticsx/analytics_x.dart';
+import 'package:test/test.dart';
+
+import 'util/vendors_and_actions.dart';
+
+void main() {
+  late FakeVendor fakeVendor;
+  late AnalyticsX ax;
+
+  setUp(() {
+    fakeVendor = FakeVendor();
+    ax = AnalyticsX();
+  });
+
+  tearDown(() {
+    ax.uninit();
+  });
+
+  test('Broken vendor does not stop other vendors from initing', () async {
+    final brokenVendor = BrokenFakeVendor(initWillThrow: true);
+    await ax.init([brokenVendor, fakeVendor]).catchError((_) => {/*nothing*/});
+
+    expect(fakeVendor.initWasCalledXTimes, 1);
+  });
+
+  test('Broken vendor that fails to init never runs actions', () async {
+    final brokenVendor = BrokenFakeVendor(initWillThrow: true);
+    await ax.init([brokenVendor, fakeVendor]).catchError((_) => {/*nothing*/});
+    await ax.invokeAction(FakeAction("potato"));
+    await ax.invokeAction(FakeAction("potato"), [brokenVendor.id]);
+    expect(brokenVendor.handleActionWasCalledXTimes, 0);
+  });
+
+  test('Broken vendor does not stop other vendors from performing actions', () async {
+    final brokenVendor = BrokenFakeVendor(handleActionWillThrow: true);
+    await ax.init([brokenVendor, fakeVendor]);
+    await ax.invokeAction(FakeAction("potato")).catchError((_) => {/*nothing*/});
+    expect(fakeVendor.handleActionWasCalledXTimes, 1);
+  });
+}

--- a/test/util/vendors_and_actions.dart
+++ b/test/util/vendors_and_actions.dart
@@ -1,0 +1,56 @@
+import 'package:analyticsx/analytics_action.dart';
+import 'package:analyticsx/analytics_vendor.dart';
+
+class FakeAction extends AnalyticsAction {
+  final String fakeProperty;
+  FakeAction(this.fakeProperty);
+}
+
+class FakeVendor extends AnalyticsVendor {
+  FakeVendor() : super('Dummy');
+  FakeVendor.withVendorId(String vendorId) : super(vendorId);
+
+  int initWasCalledXTimes = 0;
+  int handleActionWasCalledXTimes = 0;
+  List<String> handleActionWasCalledWith = [];
+
+  @override
+  Future<void> handleAction(AnalyticsAction action) async {
+    handleActionWasCalledXTimes++;
+    if (action is FakeAction) {
+      handleActionWasCalledWith.add(action.fakeProperty);
+    }
+  }
+
+  @override
+  Future<void> init() async {
+    initWasCalledXTimes++;
+  }
+}
+
+class FakeVendor2 extends FakeVendor {
+  FakeVendor2() : super.withVendorId('Dummy2');
+}
+
+class BrokenFakeVendor extends FakeVendor {
+  bool initWillThrow = true;
+  bool handleActionWillThrow = false;
+
+  BrokenFakeVendor({this.initWillThrow = false, this.handleActionWillThrow = false}) : super.withVendorId('Broken');
+
+  @override
+  Future<void> init() async {
+    if (initWillThrow) {
+      throw Exception('BrokenAnalytics threw during init()');
+    }
+    return super.init();
+  }
+
+  @override
+  Future<void> handleAction(AnalyticsAction action) async {
+    if (handleActionWillThrow) {
+      throw Exception('BrokenAnalytics threw during handleAction()');
+    }
+    return super.handleAction(action);
+  }
+}


### PR DESCRIPTION
The simplest fix, that simply "doesn't completely break" when one vendor fails.
Now, if one vendor fails to init, the other vendors will succeed, and the vendor won't be on the list of init'd vendors and could have another crack later.

~Effort of catching exceptions is still the problem of the consumer~ Fixed :)