### PR TITLE
Fixes bug where new instances of the same vendor could be init'd

### DIFF
--- a/lib/src/analytics_x.dart
+++ b/lib/src/analytics_x.dart
@@ -38,7 +38,10 @@ class AnalyticsX {
   Future<void> init(List<AnalyticsVendor> vendors, [AnalyticsError? onError]) async {
     this.onError = onError;
 
-    final newVendors = List<AnalyticsVendor>.from(vendors)..removeWhere((v) => _vendors.contains(v));
+    final uniqueVendors = _getUniqueVendorsById(vendors);
+
+    final newVendors = List<AnalyticsVendor>.from(uniqueVendors)
+      ..removeWhere((v) => _getVendorsById([v.id]).isNotEmpty);
 
     if (newVendors.isEmpty) {
       return;
@@ -83,9 +86,23 @@ class AnalyticsX {
     return _vendors.where((element) => ids.contains(element.id)).toList();
   }
 
+  List<AnalyticsVendor> _getUniqueVendorsById(List<AnalyticsVendor> vendorList) {
+    final List<String> uniqueIds = [];
+    for (final AnalyticsVendor vendor in List.from(vendorList)) {
+      if (uniqueIds.contains(vendor.id)) {
+        vendorList.remove(vendor);
+      }
+      uniqueIds.add(vendor.id);
+    }
+    return vendorList;
+  }
+
   /// Resets the list of known vendors.
   ///
   /// Doesn't perform any additional work on the [AnalyticsVendor], but permits all vendors to be passed to [init]
   /// again and have their [AnalyticsVendor.init] method invoked.
   void reset() => _vendors.clear();
+
+  /// Fetches the list of all registered (init'd) vendors
+  List<AnalyticsVendor> get allRegisteredVendors => _vendors;
 }

--- a/test/analytics_x_test.dart
+++ b/test/analytics_x_test.dart
@@ -67,4 +67,23 @@ void main() {
     await ax.invokeAction(FakeAction("potato"), ['NonExistentVendorId']);
     expect(fakeVendor.handleActionWasCalledXTimes, 0);
   });
+
+  test('AnalyticsX only registers one of each class of AnalyticsVendor when initialised together', () async {
+    final anotherFakeVendor = FakeVendor();
+    await ax.init([fakeVendor, anotherFakeVendor]);
+    expect(AnalyticsX().allRegisteredVendors.length, 1);
+  });
+
+  test('AnalyticsX only registers one of each class of AnalyticsVendor when initialised separately', () async {
+    final anotherFakeVendor = FakeVendor();
+    await ax.init([fakeVendor]);
+    await ax.init([anotherFakeVendor]);
+    expect(AnalyticsX().allRegisteredVendors.length, 1);
+  });
+
+  test('AnalyticsX only registers one AnalyticsVendor when two implementations are given the same ID', () async {
+    final anotherFakeVendor = FakeVendorWithSameID();
+    await ax.init([fakeVendor, anotherFakeVendor]);
+    expect(AnalyticsX().allRegisteredVendors.length, 1);
+  });
 }

--- a/test/util/vendors_and_actions.dart
+++ b/test/util/vendors_and_actions.dart
@@ -31,6 +31,8 @@ class FakeVendor2 extends FakeVendor {
   FakeVendor2() : super.withVendorId('Dummy2');
 }
 
+class FakeVendorWithSameID extends FakeVendor {}
+
 class BrokenFakeVendor extends FakeVendor {
   bool initWillThrow = true;
   bool handleActionWillThrow = false;


### PR DESCRIPTION
Consider the following line:

`AnalyticsX().init([MyVendor1(),MyVendor2()]`

If this line is hit twice, those are new instances of the analytics vendor and are registered, since AnalyticsVendors aren't properly equatable.

Consider this line:

`AnalyticsX().init([MyVendor1(),MyVendor1()]`

Whilst less likely, this PR also solves for this accidental misuse. 

It will also solve for the first example if MyVendor1 and MyVendor2 are AnalyticsVendor implementations using the same ID.