### PR TITLE
Make TrackEvent not require parameters

### DIFF
--- a/lib/src/actions/track_event.dart
+++ b/lib/src/actions/track_event.dart
@@ -6,7 +6,7 @@ class TrackEvent extends AnalyticsAction {
   final String eventName;
 
   /// Any parameters required or desired to accompany the event, e.g. user's analytics ID, device info, session ID
-  final Map<String, dynamic> parameters;
+  final Map<String, dynamic>? parameters;
 
-  TrackEvent(this.eventName, this.parameters);
+  TrackEvent(this.eventName, [this.parameters]);
 }

--- a/test/actions_test.dart
+++ b/test/actions_test.dart
@@ -1,0 +1,39 @@
+import 'package:analyticsx/analytics_x.dart';
+import 'package:test/test.dart';
+
+import 'util/vendors_and_actions.dart';
+
+void main() {
+  late AnalyticsX ax;
+
+  setUp(() {
+    ax = AnalyticsX();
+  });
+
+  tearDown(() {
+    ax.reset();
+  });
+
+  group('TrackEvent', () {
+    test('TrackEvent is recorded', () async {
+      const testEventName = 'test_event';
+      const testParams = {'p1': 'one', 'p2': 'two'};
+      final recordingVendor = RecordingVendor();
+
+      await ax.init([recordingVendor]);
+      await ax.invokeAction(TrackEvent(testEventName, testParams));
+
+      expect(recordingVendor.trackEventRecordings, {testEventName: testParams});
+    });
+
+    test('TrackEvent is recorded without params', () async {
+      const testEventName = 'test_event';
+      final recordingVendor = RecordingVendor();
+
+      await ax.init([recordingVendor]);
+      await ax.invokeAction(TrackEvent(testEventName));
+
+      expect(recordingVendor.trackEventRecordings, {testEventName: null});
+    });
+  });
+}

--- a/test/util/vendors_and_actions.dart
+++ b/test/util/vendors_and_actions.dart
@@ -55,3 +55,24 @@ class BrokenFakeVendor extends FakeVendor {
     return super.handleAction(action);
   }
 }
+
+class RecordingVendor extends AnalyticsVendor {
+  RecordingVendor() : super('Recorder');
+  Map<String, dynamic> trackEventRecordings = {};
+
+  @override
+  Future<void> init() async {
+    //Nothing to do
+  }
+
+  @override
+  Future<void> handleAction(AnalyticsAction action) async {
+    if (action is TrackEvent) {
+      _recordTrackEvent(action.eventName, action.parameters);
+    }
+  }
+
+  void _recordTrackEvent(String eventName, parameters) {
+    trackEventRecordings[eventName] = parameters;
+  }
+}


### PR DESCRIPTION
Parameters should always be optional, and not require an empty map to be used.

Adds the first test for bundled AnalyticsActions.